### PR TITLE
Change main file to the built, minified code

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "rescale",
     "resize"
   ],
-  "main": "fitty.js",
+  "main": "fitty.min.js",
   "author": "Rik Schennink <hello@rikschennink.nl> (http://rikschennink.nl/)",
   "license": "MIT",
   "dependencies": {},


### PR DESCRIPTION
This will allow npm users to `import fitty from 'fitty';` without needing to use babel to build the code ourselves. The fitty.js file uses the `...` ES6 operator, and cannot be imported into standard js projects while the minified version can be.  Also, it is nice to be importing minified code in general :)