### PR TITLE
Added "Pause/Resume" functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Method           | Description
 -----------------|---------------
 `fit()`          | Force a redraw of the current fitty element
 `unsubscribe()`  | Remove the fitty element from the redraw loop and restore it to its original state
+`pause()`        | Pause the scaling text even if the text is changing
+`resume()`       | Resume the scaling text and redraw it once.
 
 
 Properties       | Description
@@ -107,6 +109,12 @@ fitties[0].fit();
 
 // unsubscribe from fitty, restore to original state
 fitties[0].unsubscribe();
+
+// pause the scaling text
+fitties[0].pause();
+
+// resume the scaling text and refit it
+fitties[0].resume();
 ```
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,8 @@ declare module 'fitty' {
 
   export interface FittyInstance {
     fit: () => void
+    pause: () => void
+    resume: () => void
     unsubscribe: () => void
   }
 }

--- a/src/fitty.js
+++ b/src/fitty.js
@@ -16,7 +16,7 @@ export default ((w) => {
     DIRTY: 3
   };
   
-  let pause = false;
+  let prevent = false;
 
   // all active fitty elements
   let fitties = [];
@@ -173,7 +173,7 @@ export default ((w) => {
   
   // fit method, marks the fitty as dirty and requests a redraw (this will also redraw any other fitty marked as dirty)
   const fit = (f, type) => () => {
-    if (!pause){
+    if (!prevent){
       f.dirty = type;
       requestRedraw();
     }
@@ -181,12 +181,12 @@ export default ((w) => {
   
   //Pause the functionality. (So then text can be changed without changing the scale.)
   const pause = () => {
-    pause = true;
+    prevent = true;
   }
   
   //Resume the functionality and redraw it.
   const resume = (f, type) => {
-    pause = false;
+    prevent = false;
     fit(f, type);
   }
 

--- a/src/fitty.js
+++ b/src/fitty.js
@@ -180,12 +180,12 @@ export default ((w) => {
   };
   
   //Pause the functionality. (So then text can be changed without changing the scale.)
-  const pause = () => {
+  const pause = () => () => {
     prevent = true;
   }
   
   //Resume the functionality and redraw it.
-  const resume = (f, type) => {
+  const resume = (f, type) => () => {
     prevent = false;
     fit(f, type);
   }

--- a/src/fitty.js
+++ b/src/fitty.js
@@ -15,6 +15,8 @@ export default ((w) => {
     DIRTY_LAYOUT: 2,
     DIRTY: 3
   };
+  
+  let pause = false;
 
   // all active fitty elements
   let fitties = [];
@@ -168,14 +170,25 @@ export default ((w) => {
       }
     }));
   };
-
-
+  
   // fit method, marks the fitty as dirty and requests a redraw (this will also redraw any other fitty marked as dirty)
   const fit = (f, type) => () => {
-    f.dirty = type;
-    requestRedraw();
+    if (!pause){
+      f.dirty = type;
+      requestRedraw();
+    }
   };
-
+  
+  //Pause the functionality. (So then text can be changed without changing the scale.)
+  const pause = () => {
+    pause = true;
+  }
+  
+  //Resume the functionality and redraw it.
+  const resume = (f, type) => {
+    pause = false;
+    fit(f, type);
+  }
 
   // add a new fitty, does not redraw said fitty
   const subscribe = f => {
@@ -278,6 +291,8 @@ export default ((w) => {
       return {
         element,
         fit: fit(f, DrawState.DIRTY),
+        pause: pause(),
+        resume: resume(f, DrawState.DIRTY),
         unsubscribe: unsubscribe(f)
       };
 


### PR DESCRIPTION
With this functionality, you're allowed to pause the scaling text even if the text content is changed. (And resume it)

Following were added:

```js
fitty.pause() //pause the scaling
fitty.resume() //resume it and redraw it once.
```