### PR TITLE
Add missing TypeScript type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ declare module 'fitty' {
   export default fitty
 
   export interface FittyInstance {
+    element: HTMLElement
     fit: () => void
     freeze: () => void
     unfreeze: () => void


### PR DESCRIPTION
This pull request adds TypeScript type for `element` missing in `FittyInstance`.