### PR TITLE
Enable the `styleComputed` flag

### DIFF
--- a/src/fitty.js
+++ b/src/fitty.js
@@ -107,6 +107,8 @@ export default ((w) => {
     // get display type and wrap mode
     f.display = style.getPropertyValue('display');
     f.whiteSpace = style.getPropertyValue('white-space');
+
+    return true
   };
 
 


### PR DESCRIPTION
Thank you for creating this great library.

The `styleComputed` flag doesn't work, because the `computeStyle` function return void.

Please check this [codesandbox](https://codesandbox.io/s/prevent-multiple-calls-s5k13). In the 'before' page, `computeStyle` is called twice, but in the 'after' page, it called only onece.