### PR TITLE
fix: export types from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "resize"
     ],
     "main": "dist/fitty.module.js",
+    "types": "index.d.ts",
     "author": "Rik Schennink <rik@pqina.nl> (https://pqina.nl/)",
     "license": "MIT",
     "devDependencies": {


### PR DESCRIPTION
Types aren't exporting properly when I tried to import fitty in my typescript application. We need to set the `types` property in `package.json` to point to the bundled declaration file.

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package