### PR TITLE
Change entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "rescale",
         "resize"
     ],
-    "main": "dist/fitty.module.js",
+    "main": "dist/fitty.min.js",
     "types": "index.d.ts",
     "author": "Rik Schennink <rik@pqina.nl> (https://pqina.nl/)",
     "license": "MIT",


### PR DESCRIPTION
Fix `SyntaxError: Unexpected token 'export'` when import the library


issue #76 